### PR TITLE
Fix bug - password length and zip

### DIFF
--- a/make_matcher_frontend/src/app/components/SignupComponent/index.jsx
+++ b/make_matcher_frontend/src/app/components/SignupComponent/index.jsx
@@ -151,8 +151,8 @@ export function SignupComponent() {
           className="form-inputs"
           pattern="[0-9]{5}"
           title="Five digit zip code"
-          onBlur={() => handleInputFocus('zip-code')}
-          onChange={e => handleEnteredValues('zip-code', e.target.value)}
+          onBlur={() => handleInputFocus('zipCode')}
+          onChange={e => handleEnteredValues('zipCode', e.target.value)}
           error={zipCodeIsInvalid && 'Please enter a valid zip code!'}
         />
         <InputComponent

--- a/make_matcher_frontend/src/utils/validation.js
+++ b/make_matcher_frontend/src/utils/validation.js
@@ -6,8 +6,8 @@ export function isNotEmpty(value) {
   return value.trim() !== '';
 }
 
-export function hasMinLength(value, minLength, maxLength) {
-  return value.length >= minLength && value.length <= maxLength;
+export function hasMinLength(value, minLength) {
+  return value.length >= minLength;
 }
 
 export function isEqualsToOtherValue(value, otherValue) {


### PR DESCRIPTION
1) "zipCode" in the useState, 
but here, you used "zip-code":
onBlur={() => handleInputFocus('zip-code')}
onChange={e => handleEnteredValues('zip-code', e.target.value)}
- fixed, replaced with "zipCode"

2) 
let passwordIsInvalid =
    didChange.password && !hasMinLength(enteredValues.password.trim(), 8); // you passed only 2 input args to "hasMinLength", 
but in utils/validation.js, your function was defined for 3:
export function hasMinLength(value, minLength, maxLength) { 
  return value.length >= minLength && value.length <= maxLength;
}
- fixed, removed maxLength constraint

![image](https://github.com/makematcher/make_matcher/assets/87253511/ca18b163-51d9-4b22-9d13-3a348976ab6e)
