### PR TITLE
Add matches endpoints/rework model/tests

### DIFF
--- a/make_matcher_backend/app/controllers/api/matches_controller.rb
+++ b/make_matcher_backend/app/controllers/api/matches_controller.rb
@@ -1,0 +1,13 @@
+class Api::MatchesController < Api::Controller
+  before_action :authorized_user
+
+  def index
+    render json: { matches: current_user.matches.map {|m| MatchSerializer.new(m) } }
+  end
+
+  def destroy
+    Match.where(matcher_id: current_user.profile.id, matched_id: params[:id]).or(Match.where(matcher_id: params[:id], matched_id: current_user.profile.id)).destroy_all
+
+    render json: { message: "Success" }, status: :ok
+  end
+end

--- a/make_matcher_backend/app/models/profile.rb
+++ b/make_matcher_backend/app/models/profile.rb
@@ -18,9 +18,7 @@ class Profile < ApplicationRecord
   # Associations
   belongs_to :user
   has_and_belongs_to_many :games
-  def matches
-    Match.where("matcher_id = :id OR matched_id = :id", id:)
-  end
+  has_many :matches, foreign_key: :matcher_id
 
   # Callbacks
   before_save :locate

--- a/make_matcher_backend/app/models/user.rb
+++ b/make_matcher_backend/app/models/user.rb
@@ -11,4 +11,5 @@ class User < ApplicationRecord
   has_many :group_memberships, foreign_key: :user_id
   has_many :groups, through: :group_memberships
   has_many :friend_requests, class_name: "FriendRequest", foreign_key: :requestee_id
+  has_many :matches, through: :profile
 end

--- a/make_matcher_backend/app/serializers/match_serializer.rb
+++ b/make_matcher_backend/app/serializers/match_serializer.rb
@@ -1,0 +1,7 @@
+class MatchSerializer < ActiveModel::Serializer
+  type :match
+
+  attributes :id, :matched_id
+
+  has_one :matched, serializer: ProfileSerializer
+end

--- a/make_matcher_backend/config/routes.rb
+++ b/make_matcher_backend/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
     end
     resources :friends, only: [:create, :index, :destroy]
     resources :friend_requests, only: [:create, :index, :destroy]
+    resources :matches, only: [:index, :destroy]
 
     # Profiles
     get     "profile",            to: "profiles#edit"

--- a/make_matcher_backend/db/schema.rb
+++ b/make_matcher_backend/db/schema.rb
@@ -15,8 +15,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_27_161733) do
   enable_extension "plpgsql"
 
   create_table "api_keys", force: :cascade do |t|
-    t.string "key", default: "ksuk_edd7780bfeba046406782a1a67792002"
-    t.string "secret", default: "ksus_479baf6b252ec4bee32ff5de9c9f52d7"
+    t.string "key", default: "ksuk_3acfb725f860521abe04453c0cdd8be6"
+    t.string "secret", default: "ksus_ecadb6293bd7c92d3b96ee17f6468607"
     t.string "name"
     t.boolean "active"
     t.datetime "created_at", null: false

--- a/make_matcher_backend/spec/models/match_spec.rb
+++ b/make_matcher_backend/spec/models/match_spec.rb
@@ -1,5 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Match, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "relations" do
+    it { should belong_to(:matcher) }
+    it { should belong_to(:matched) }
+  end
 end

--- a/make_matcher_backend/spec/models/user_spec.rb
+++ b/make_matcher_backend/spec/models/user_spec.rb
@@ -1,6 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  describe "relations" do
+    it { should have_one(:profile) }
+    it { should have_many(:friends) }
+    it { should have_many(:groups) }
+    it { should have_many(:friend_requests) }
+    it { should have_many(:matches) }
+  end
+
   describe "validations" do
     it { should validate_presence_of(:username) }
     it { should validate_uniqueness_of(:username) }

--- a/make_matcher_backend/spec/requests/matches_spec.rb
+++ b/make_matcher_backend/spec/requests/matches_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe "Matches", type: :request do
+  describe "GET /matches" do
+    context "authorized" do
+      it "returns current user matches" do
+        headers = authenticated_headers
+        Match.create!(matcher_id: User.last.profile.id, matched_id: User.last.profile.id)
+
+        get "/api/matches", headers: headers
+
+        expect(json.dig("matches", 0, "matched_id")).to eq(User.last.id)
+        expect(json.dig("matches", 0, "matched", "display_name")).to eq(User.last.username)
+      end
+    end
+
+    context "unauthorized" do
+      it "returns 401" do
+        get "/api/matches", headers: api_headers
+        expect(json["message"]).to eq("Unauthorized")
+        expect(response.status).to eq(401)
+      end
+    end
+  end
+
+  describe "DELETE /matches/:profile_id" do
+    context "authorized" do
+      it "delete current user match" do
+        headers = authenticated_headers
+        Match.create!(matcher_id: User.last.profile.id, matched_id: User.last.profile.id)
+
+        delete "/api/matches/#{User.last.profile.id}", headers: headers
+
+        expect(User.last.matches).to be_empty
+      end
+    end
+
+    context "unauthorized" do
+      it "returns 401" do
+        delete "/api/matches/0", headers: api_headers
+        expect(json["message"]).to eq("Unauthorized")
+        expect(response.status).to eq(401)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Made matches 'directional' - current user only sees matches where they are 'matcher'
This means, to create a match, create both directions

However, deletion logic currently deletes both directions if one requests to be deleted